### PR TITLE
Add Node CLI skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill in your keys
+OPENAI_API_KEY=
+# Optional Adobe PDF Accessibility Auto-Tag API
+ADOBE_PDF_CLIENT_ID=
+ADOBE_PDF_CLIENT_SECRET=

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+# PDF-Remediation
+
+CLI tool that turns any PDF into a more accessible version  
+by adding alt-text, a tag tree, page bookmarks, and metadata  
+— all powered by the OpenAI API.
+
+```bash
+# Quick start (after Codex generates the files)
+cp .env.example .env            # paste your OpenAI key
+npm install                     # Codex already ran this once
+node src/cli.js remediate \
+     --in sample.pdf \
+     --out sample_a11y.pdf \
+     --alt --tags --summaries
+```
+
+What it does
+StageModelResult
+Alt-textgpt-4o-mini (vision)Adds /Alt text to every image
+Tag tree & bookmarksgpt-4.1-nanoDetects H1/H2/… → bookmarks
+Summaries & metadatagpt-4.1-nano≤ 35-word summaries, title, keywords
+
+Requirements on your machine
+Node 20+ and npm
+
+Internet access for the OpenAI API
+
+OPENAI_API_KEY in .env (billing-enabled)
+
+(Optional) Adobe PDF Accessibility API keys if you later extend the workflow.
+
+MIT License · © 2025

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+"name": "pdf-remediation",
+"version": "0.1.0",
+"type": "module",
+"description": "AI-powered PDF accessibility remediation (alt-text, tagging, summaries).",
+"bin": {
+"pdf-remediate": "./src/cli.js"
+},
+"scripts": {
+"start": "node src/cli.js",
+"remediate": "node src/cli.js remediate"
+},
+"dependencies": {
+"commander": "^11.1.0",
+"dotenv": "^16.4.0",
+"openai": "^4.25.0",
+"pdf-lib": "^1.19.0",
+"pdfjs-dist": "^4.3.136"
+}
+}

--- a/src/ai.js
+++ b/src/ai.js
@@ -1,0 +1,15 @@
+import OpenAI from "openai";
+export const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+/** Simple wrapper around Chat Completions. */
+export async function chat(model, system, user) {
+  const { choices } = await openai.chat.completions.create({
+    model,
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user }
+    ],
+    temperature: 0.2
+  });
+  return choices[0].message.content.trim();
+}

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import { program } from "commander";
+import "dotenv/config";
+import { addAltText } from "./workflows/altText.js";
+import { addTagTree } from "./workflows/tagging.js";
+import { addSummaries } from "./workflows/summaries.js";
+
+program
+  .name("pdf-remediate")
+  .command("remediate")
+  .requiredOption("--in <pdf>", "input PDF path")
+  .requiredOption("--out <pdf>", "output PDF path")
+  .option("--alt", "generate alt-text")
+  .option("--tags", "generate tag tree")
+  .option("--summaries","generate summaries & bookmarks")
+  .action(async opts => {
+    const { in: input, out: output, alt, tags, summaries } = opts;
+    if (!alt && !tags && !summaries) {
+      console.error("Nothing to do — add --alt, --tags or --summaries.");
+      process.exit(1);
+    }
+
+    let pdfBytes = await fs.readFile(input);
+
+    if (alt)       pdfBytes = await addAltText(pdfBytes);
+    if (tags)      pdfBytes = await addTagTree(pdfBytes);
+    if (summaries) pdfBytes = await addSummaries(pdfBytes);
+
+    await fs.writeFile(output, pdfBytes);
+    console.log("✅  Remediated PDF saved to", output);
+  });
+
+program.parse(process.argv);

--- a/src/pdf.js
+++ b/src/pdf.js
@@ -1,0 +1,22 @@
+import { PDFDocument } from "pdf-lib";
+import pdfjs from "pdfjs-dist/legacy/build/pdf.js";
+
+/** Extract plaintext for every page using pdfjs-dist. */
+export async function extractTextPerPage(pdfBytes) {
+  const doc = await pdfjs.getDocument({ data: pdfBytes }).promise;
+  const out = [];
+  for (let p = 1; p <= doc.numPages; p++) {
+    const page = await doc.getPage(p);
+    const c = await page.getTextContent();
+    out.push(c.items.map(i => i.str).join("\n"));
+  }
+  return out;
+}
+
+/** Low-level helper to attach /Alt text to an image XObject. */
+export function embedAltText(page, name, alt) {
+  const res = page.node.Resources();
+  const xo = res?.lookup("XObject");
+  const ref = xo?.lookup(name);
+  if (ref) ref.set("Alt", page.doc.context.obj(alt));
+}

--- a/src/workflows/altText.js
+++ b/src/workflows/altText.js
@@ -1,0 +1,29 @@
+import { PDFDocument } from "pdf-lib";
+import { chat } from "../ai.js";
+import { embedAltText } from "../pdf.js";
+
+const MODEL = "gpt-4o-mini"; // cheapest vision tier
+
+export async function addAltText(pdfBytes) {
+  const pdf = await PDFDocument.load(pdfBytes);
+
+  for (const page of pdf.getPages()) {
+    const res = page.node.Resources();
+    const xo = res?.lookup("XObject");
+    if (!xo) continue;
+    for (const [name, ref] of xo.entries()) {
+      const img = page.doc.context.lookup(ref);
+      const bytes = img.contents;
+      if (!bytes) continue;
+
+      const b64 = bytes.slice(0, 20_000).toString("base64");
+      const alt = await chat(
+        MODEL,
+        "You are an accessibility expert. Provide concise (≤20 words) alt-text.",
+        `Image (base64, truncated): ${b64}`
+      );
+      embedAltText(page, name, alt);
+    }
+  }
+  return pdf.save();
+}

--- a/src/workflows/summaries.js
+++ b/src/workflows/summaries.js
@@ -1,0 +1,26 @@
+import { PDFDocument } from "pdf-lib";
+import { extractTextPerPage } from "../pdf.js";
+import { chat } from "../ai.js";
+
+const MODEL = "gpt-4.1-nano";
+
+export async function addSummaries(pdfBytes) {
+  const pdf = await PDFDocument.load(pdfBytes);
+  const pages = await extractTextPerPage(pdfBytes);
+
+  for (let i = 0; i < pages.length; i++) {
+    const summary = await chat(
+      MODEL,
+      "Summarise this page in ≤35 words.",
+      pages[i].slice(0, 8000)
+    );
+    const page = pdf.getPages()[i];
+    pdf.catalog.addOutline(`Pg ${i + 1}: ${summary}`, page.ref);
+  }
+
+  pdf.setTitle("Remediated PDF");
+  pdf.setSubject("Accessibility-enhanced PDF");
+  pdf.setKeywords(["accessibility", "alt-text", "PDF remediation"]);
+
+  return pdf.save();
+}

--- a/src/workflows/tagging.js
+++ b/src/workflows/tagging.js
@@ -1,0 +1,26 @@
+import { PDFDocument } from "pdf-lib";
+import { extractTextPerPage } from "../pdf.js";
+import { chat } from "../ai.js";
+
+const MODEL = "gpt-4.1-nano"; // cheapest text tier
+
+export async function addTagTree(pdfBytes) {
+  const pdf = await PDFDocument.load(pdfBytes);
+  const pages = await extractTextPerPage(pdfBytes);
+
+  for (let i = 0; i < pages.length; i++) {
+    const raw = pages[i].slice(0, 8000);
+    const json = await chat(
+      MODEL,
+      "Label each line with H1, H2, P, LI, TH, TD. Return JSON array.",
+      raw
+    );
+    let roles;
+    try { roles = JSON.parse(json); } catch { continue; }
+    const page = pdf.getPages()[i];
+    roles
+      .filter(r => r.role === "H1" || r.role === "H2")
+      .forEach(r => pdf.catalog.addOutline(r.text.slice(0, 60), page.ref));
+  }
+  return pdf.save();
+}


### PR DESCRIPTION
## Summary
- initialize PDF-Remediation CLI with alt-text, tagging, and summary workflows
- add configuration and example environment file

## Testing
- `npm install --silent --loglevel error` *(failed: no output - network restrictions?)*